### PR TITLE
Added support for S3 Server Side Encryption

### DIFF
--- a/AwsGrailsPlugin.groovy
+++ b/AwsGrailsPlugin.groovy
@@ -2,7 +2,7 @@ import grails.plugin.aws.meta.AwsPluginSupport
 
 class AwsGrailsPlugin {
 
-    def version                  = "1.2.12.2"
+    def version                  = "1.2.12.3"
     def grailsVersion            = "1.3.0 > *"
     def dependsOn                = [:]
     def loadAfter                = ['services', 'controllers']

--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,7 @@
 #Grails Metadata file
-#Tue May 10 10:11:48 BRT 2011
+#Sun Sep 30 16:14:46 IST 2012
 app.grails.version=1.3.7
 app.name=aws
 plugins.hibernate=1.3.7
+plugins.svn=1.0.2
 plugins.tomcat=1.3.7

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,7 +17,7 @@ grails.project.dependency.resolution = {
     }
 
 	dependencies {
-        compile 'net.java.dev.jets3t:jets3t:0.8.1'
+        compile 'net.java.dev.jets3t:jets3t:0.9.0'
         compile 'javax.mail:mail:1.4.1'
         compile 'commons-httpclient:commons-httpclient:3.1'
         compile 'commons-logging:commons-logging:1.1.1'

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<plugin name='aws' version='1.2.12.1' grailsVersion='1.3.0 &gt; *'>
+<plugin name='aws' version='1.2.12.3' grailsVersion='1.3.0 &gt; *'>
   <author>Lucas Teixeira</author>
   <authorEmail>lucastex@gmail.com</authorEmail>
   <title>Grails AWS Plugin</title>

--- a/src/docs/guide/2.2.7 Using Server Side Encryption.gdoc
+++ b/src/docs/guide/2.2.7 Using Server Side Encryption.gdoc
@@ -1,0 +1,9 @@
+AWS S3 files can be stored encrypted in S3, and AWS allows you to specify this as a request header.
+To use this, simply set the useEncryption property to 'true' in the file upload closure. The plugin
+will set the header for encryption and the file will be encrypted using AES-256 algorithm by AWS before storing in S3.
+
+{code}
+def uploadedFile = new File("/tmp/test.txt").s3upload {
+    useEncryption true
+}
+{code}

--- a/src/groovy/grails/plugin/aws/s3/S3FileUpload.groovy
+++ b/src/groovy/grails/plugin/aws/s3/S3FileUpload.groovy
@@ -16,6 +16,7 @@ class S3FileUpload {
 	def bucket
 	def bucketLocation
 	def credentialsHolder
+	def useEncryption
 	
 	//configured by user
 	String path
@@ -61,6 +62,12 @@ class S3FileUpload {
 		log.debug "setting rrs name to '${rrs}'"
 	}
 	
+	//whether to use server side encryption
+	void useEncryption(_useEncryption) {
+		this.useEncryption = _useEncryption
+		log.debug "setting useEncryption preference to '${useEncryption}'"
+	}
+
 	//upload method for inputstreams
 	def inputStreamUpload(InputStream inputStream, String name, Closure cls) {
 		
@@ -126,6 +133,10 @@ class S3FileUpload {
 			s3Object.setStorageClass(S3Object.STORAGE_CLASS_REDUCED_REDUNDANCY)
 		}
 		
+		if (useEncryption) {
+			s3Object.setServerSideEncryptionAlgorithm(S3Object.SERVER_SIDE_ENCRYPTION__AES256)
+		}
+
 		return s3Object
 	}
 	

--- a/test/unit/aws/S3FileUploadTests.groovy
+++ b/test/unit/aws/S3FileUploadTests.groovy
@@ -72,6 +72,14 @@ class S3FileUploadTests extends GrailsUnitTestCase {
 		s3fu.rrs(false)
 		assertFalse s3fu.rrs
     }
+	
+	void testSetUseEncryption() {
+		def s3fu = new S3FileUpload()
+		s3fu.log = new MockLogger()
+		
+		s3fu.useEncryption(true)
+		assertTrue s3fu.useEncryption
+	}
 
 	void testSetClosureData() {
 
@@ -86,6 +94,7 @@ class S3FileUploadTests extends GrailsUnitTestCase {
 		    acl      "private"
 		  	rrs      true
 		    metadata metaValues
+			useEncryption	false
 		}
 		
 		assertEquals "test-bucket", s3fu.bucket
@@ -94,6 +103,7 @@ class S3FileUploadTests extends GrailsUnitTestCase {
 	    assertEquals "private", s3fu.acl
 	    assertEquals true, s3fu.rrs
 		assertEquals metaValues, s3fu.metadata
+		assertEquals false, s3fu.useEncryption
 	}
 	
 	void testValidateBucketName_Ok() {
@@ -158,6 +168,7 @@ class S3FileUploadTests extends GrailsUnitTestCase {
 			acl      "private"
 			rrs      true
 			metadata metaValues
+			useEncryption	true
 		}
 		
 		def s3Object  = s3fu.buildS3Object(new S3Object(), "key-name")
@@ -168,5 +179,6 @@ class S3FileUploadTests extends GrailsUnitTestCase {
 		metaValues.each { meta, value ->
 			assertEquals  value, s3Object.getModifiableMetadata()[meta]
 		}
+		assertEquals	S3Object.SERVER_SIDE_ENCRYPTION__AES256, s3Object.getServerSideEncryptionAlgorithm()
 	}
 }


### PR DESCRIPTION
To use S3 server side encryption, a newer version of JetS3t library was required, so upgraded to 0.9.0. Also made changes to S3FilUpload.groovy to set the the encryption header and to allow the user to specify the preference for encryption.

Added tests and updated the documentation to depict the usage of new property.
