### PR TITLE
Check type of awsRegion & call appropriate sesService.setRegion() setter

### DIFF
--- a/src/groovy/grails/plugin/aws/ses/SendSesMail.groovy
+++ b/src/groovy/grails/plugin/aws/ses/SendSesMail.groovy
@@ -192,7 +192,7 @@ class SendSesMail {
 	def sendSimpleMail(_from, _destination, _message) {
 		def credentials	 = credentialsHolder.buildAwsSdkCredentials()
 		def sesService	 = new AmazonSimpleEmailServiceClient(credentials)
-        sesService.region = awsRegion
+        sesService.setRegion(awsRegion)
 		def emailRequest = new SendEmailRequest(_from, _destination, _message)
 
 		if (replyTo) {

--- a/src/groovy/grails/plugin/aws/ses/SendSesMail.groovy
+++ b/src/groovy/grails/plugin/aws/ses/SendSesMail.groovy
@@ -192,7 +192,14 @@ class SendSesMail {
 	def sendSimpleMail(_from, _destination, _message) {
 		def credentials	 = credentialsHolder.buildAwsSdkCredentials()
 		def sesService	 = new AmazonSimpleEmailServiceClient(credentials)
-        sesService.setRegion(awsRegion)
+
+		//Fix to #51 - Checking the instance type, else is not supposed to be ever reached, but just in case ...
+		if(awsRegion instanceof Region){
+			sesService.setRegion((Region)awsRegion)
+		}else{
+			sesService.region = awsRegion
+		}
+
 		def emailRequest = new SendEmailRequest(_from, _destination, _message)
 
 		if (replyTo) {


### PR DESCRIPTION
I believe it's more reliable to explicitly check the type of the `awsRegion` variable and then call the appropriate setter method. The `else` is never expected to be reached in normal use with this plugin.

This has fixed the exception caused.